### PR TITLE
Interactively ask mem size and core number

### DIFF
--- a/data/data/ovirt/main.tf
+++ b/data/data/ovirt/main.tf
@@ -17,8 +17,8 @@ resource "ovirt_vm" "master" {
   name        = "master-${count.index}.${var.cluster_domain}"
   cluster_id  = var.ovirt_cluster_id
   template_id = var.ovirt_template_id
-  memory      = "8192"
-  cores       = "4"
+  memory      = var.ovirt_node_mem
+  cores       = var.ovirt_node_cores
 
   initialization {
     host_name     = "master-${count.index}.local"

--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -45,3 +45,15 @@ variable "ovirt_template_id" {
   default     = ""
   description = "The ID of cluster"
 }
+
+variable "ovirt_node_mem" {
+  type = string
+  default = "8192"
+  description = "Mem allocated on OCP node VMs"
+}
+
+variable "ovirt_node_cores" {
+  type = string
+  default = "4"
+  description = "Cores allocated on OCP node VMs"
+}

--- a/pkg/asset/cluster/ovirt/ovirt.go
+++ b/pkg/asset/cluster/ovirt/ovirt.go
@@ -16,5 +16,7 @@ func Metadata(config *types.InstallConfig) *ovirt.Metadata {
 		APIVIP:     config.Platform.Ovirt.APIVIP,
 		DNSVIP:     config.Platform.Ovirt.DNSVIP,
 		IngressVIP: config.Platform.Ovirt.IngressVIP,
+		NodeMem:    config.Platform.Ovirt.NodeMem,
+		NodeCores:  config.Platform.Ovirt.NodeCores,
 	}
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -361,6 +361,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.Ovirt.Cafile,
 			installConfig.Config.Platform.Ovirt.ClusterID,
 			installConfig.Config.Platform.Ovirt.TemplateID,
+			installConfig.Config.Platform.Ovirt.NodeMem,
+			installConfig.Config.Platform.Ovirt.NodeCores,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -137,6 +137,28 @@ func Platform() (*ovirt.Platform, error) {
 	err = survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
+				Message: "Enter how much memory (MB) you want to allocate for each node",
+				Help:    "RAM to allocate for each OCP node",
+				Default: "8192",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &p.NodeMem)
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Enter how many cores you want to allocate for each node",
+				Help:    "number of cores to allocate for each OCP node",
+				Default: "4",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &p.NodeCores)
+
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
 				Message: "Enter the internal API Virtual IP",
 				Help:    "Make sure the ip is not used by any party",
 				Default: "",

--- a/pkg/tfvars/ovirt/ovirt.go
+++ b/pkg/tfvars/ovirt/ovirt.go
@@ -6,12 +6,14 @@ import (
 )
 
 type config struct {
-	URL        string `json:"ovirt_url,omitempty"`
-	Username   string `json:"ovirt_username,omitempty"`
-	Password   string `json:"ovirt_password,omitempty"`
-	Cafile     string `json:"ovirt_cafile,omitempty"`
-	ClusterID  string `json:"ovirt_cluster_id,omitempty"`
-	TemplateID string `json:"ovirt_template_id,omitempty"`
+	URL               string `json:"ovirt_url,omitempty"`
+	Username          string `json:"ovirt_username,omitempty"`
+	Password          string `json:"ovirt_password,omitempty"`
+	Cafile            string `json:"ovirt_cafile,omitempty"`
+	ClusterID         string `json:"ovirt_cluster_id,omitempty"`
+	TemplateID        string `json:"ovirt_template_id,omitempty"`
+	NodeMem           string `json:"ovirt_node_mem,omitempty"`
+	NodeCores         string `json:"ovirt_node_cores,omitempty"`
 }
 
 // TFVars generates ovirt-specific Terraform variables.
@@ -21,15 +23,19 @@ func TFVars(
 	enginePass string,
 	engineCafile string,
 	clusterID string,
-	templateID string) ([]byte, error) {
+	templateID string,
+	nodeMem string,
+	nodeCores string) ([]byte, error) {
 
 	cfg := config{
-		URL:        engineURL,
-		Username:   engineUser,
-		Password:   enginePass,
-		Cafile:     engineCafile,
-		ClusterID:  clusterID,
-		TemplateID: templateID,
+		URL:               engineURL,
+		Username:          engineUser,
+		Password:          enginePass,
+		Cafile:            engineCafile,
+		ClusterID:         clusterID,
+		TemplateID:        templateID,
+		NodeMem:           nodeMem,
+		NodeCores:         nodeCores,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/ovirt/metadata.go
+++ b/pkg/types/ovirt/metadata.go
@@ -2,11 +2,13 @@ package ovirt
 
 // Metadata contains ovirt metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	URL        string `json:"url"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	Cafile     string `json:"cafile"`
-	APIVIP     string `json:"api_vip"`
-	DNSVIP     string `json:"dns_vip"`
-	IngressVIP string `json:"ingress_vip"`
+	URL         string `json:"url"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	Cafile      string `json:"cafile"`
+	APIVIP      string `json:"api_vip"`
+	DNSVIP      string `json:"dns_vip"`
+	IngressVIP  string `json:"ingress_vip"`
+	NodeMem     string `json:"node_mem"`
+	NodeCores   string `json:"node_cores"`
 }

--- a/pkg/types/ovirt/platform.go
+++ b/pkg/types/ovirt/platform.go
@@ -28,4 +28,7 @@ type Platform struct {
 	// ingressIP is an external IP which routes to the default ingress controller.
 	// The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
 	IngressVIP string `json:"ingress_vip,omitempty"`
+
+	NodeMem string `json:"node_mem,omitempty"`
+	NodeCores string `json:"node_cores,omitempty"`
 }


### PR DESCRIPTION
Let the user interactively specify a custom
mem size and core number for OCP node VMs
at install time.